### PR TITLE
Added aria-expanded to dropdown navigation

### DIFF
--- a/src/_includes/components/header.njk
+++ b/src/_includes/components/header.njk
@@ -10,6 +10,22 @@
 
 		<div class="c-header__nav-container js-nav-panel">
 			{% include "components/tree-nav.njk" %}
+
+			<script type="text/javascript">
+			function toggle(id, id2) {
+				var n = document.getElementById(id);
+				if (n.style.display != 'none') 
+				{
+				n.style.display = 'none';
+				document.getElementById(id2).setAttribute('aria-expanded', 'false');
+			}
+			else
+			{
+			n.style.display = '';
+			document.getElementById(id2).setAttribute('aria-expanded', 'true');
+				}
+			}
+			</script>
 		</div>
 	</div>
 	<!--end c-header__inner-->

--- a/src/_includes/components/header.njk
+++ b/src/_includes/components/header.njk
@@ -11,24 +11,11 @@
 		<div class="c-header__nav-container js-nav-panel">
 			{% include "components/tree-nav.njk" %}
 
-			<script type="text/javascript">
-			function toggle(id, id2) {
-				var n = document.getElementById(id);
-				if (n.style.display != 'none') 
-				{
-				n.style.display = 'none';
-				document.getElementById(id2).setAttribute('aria-expanded', 'false');
-			}
-			else
-			{
-			n.style.display = '';
-			document.getElementById(id2).setAttribute('aria-expanded', 'true');
-				}
-			}
-			</script>
+			
+		
 		</div>
 	</div>
 	<!--end c-header__inner-->
 </header>
-<!--end c-header-->
+<!--end c-header--> 
 

--- a/src/_includes/components/tree-nav.njk
+++ b/src/_includes/components/tree-nav.njk
@@ -5,10 +5,12 @@
         {% for item in navigation.items %}
         <li class="c-tree-nav__item {% if item.subnav %}js-nav-dropdown{% endif %}">
             {% if item.subnav %}
-            <button class="c-tree-nav__link c-tree-nav__link--btn js-nav-dropdown-trigger">
+            <button class="c-tree-nav__link c-tree-nav__link--btn js-nav-dropdown-trigger" aria-expanded="true">
                 {{ item.label }}
                 {% set className = "c-tree-nav__icon" %}
                 {% include "components/icon-chevron-down.njk" %}
+           
+                
                 
             </button>
             

--- a/src/js/primary-nav.js
+++ b/src/js/primary-nav.js
@@ -23,10 +23,15 @@
       if (navLinkParent.classList.contains('is-active')) {
         /* 3 */
         navLinkParent.classList.remove('is-active');
+        
+        this.setAttribute("aria-expanded", "false");
       } else {
         /* 4 */
         navLinkParent.classList.add('is-active');
+       
+        this.setAttribute("aria-expanded", "true");
       }
+      
     });
   }
 


### PR DESCRIPTION
Following comment is also in issues:

Found this code which I added to header.njk

Not sure if this will work. Inserting JS into HTML and I'm a little cloudy on everything the JS is doing.

Basically I copy/pasted aria code to add the property to c-header__nav-container js-nav-panel

<div class="c-header__nav-container js-nav-panel">
	{% include "components/tree-nav.njk" %}

	<script type="text/javascript">
		function toggle(id, id2) {
			var n = document.getElementById(id);
			if (n.style.display != 'none')
			         {
				n.style.display = 'none';
				document.getElementById(id2).setAttribute('aria-expanded', 'false');
			         }
			else
			        {
			n.style.display = '';
			document.getElementById(id2).setAttribute('aria-expanded', 'true');
				}
			}
	</script>
</div>